### PR TITLE
Add Key binding to craft/forge/reroll in many of the VH interfaces

### DIFF
--- a/src/main/java/io/iridium/qolhunters/QOLHunters.java
+++ b/src/main/java/io/iridium/qolhunters/QOLHunters.java
@@ -3,6 +3,7 @@ package io.iridium.qolhunters;
 import com.mojang.logging.LogUtils;
 
 import io.iridium.qolhunters.config.QOLHuntersClientConfigs;
+import io.iridium.qolhunters.util.KeyBindings;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.EventPriority;
@@ -38,6 +39,7 @@ public class QOLHunters {
     }
 
     private void clientSetup(final FMLClientSetupEvent event) {
+        KeyBindings.init();
     }
 
     private void commonSetup(final FMLCommonSetupEvent event) {

--- a/src/main/java/io/iridium/qolhunters/QOLHuntersMixinPlugin.java
+++ b/src/main/java/io/iridium/qolhunters/QOLHuntersMixinPlugin.java
@@ -20,8 +20,10 @@ public final class QOLHuntersMixinPlugin implements IMixinConfigPlugin {
     private static boolean vanillaSafeMode = false;
     private static boolean betterDescriptions = true;
     private static boolean vaultModifierOverlays = true;
+    private static boolean vaultInterfaceKeybinds = true;
     private static boolean vaultEnchanterEmeraldSlot = true;
     private static boolean isWoldsVaultModInstalled = false;
+
 
 
     private static final Supplier<Boolean> TRUE = () -> true;
@@ -46,6 +48,12 @@ public final class QOLHuntersMixinPlugin implements IMixinConfigPlugin {
     );
 
 
+    private static final Map<String, Supplier<Boolean>> VAULT_KEYBINDS_CONDITIONS = ImmutableMap.of(
+            "io.iridium.qolhunters.mixin.keybinds.MixinBountyScreen", () -> QOLHuntersMixinPlugin.vaultInterfaceKeybinds,
+            "io.iridium.qolhunters.mixin.keybinds.MixinForgeRecipeContainerScreen", () -> QOLHuntersMixinPlugin.vaultInterfaceKeybinds,
+            "io.iridium.qolhunters.mixin.keybinds.MixinModifierWorkbenchScreen", () -> QOLHuntersMixinPlugin.vaultInterfaceKeybinds,
+            "io.iridium.qolhunters.mixin.keybinds.MixinVaultEnchanterScreen", () -> QOLHuntersMixinPlugin.vaultInterfaceKeybinds
+    );
 
 
 
@@ -55,8 +63,8 @@ public final class QOLHuntersMixinPlugin implements IMixinConfigPlugin {
     private static final String VANILLA_SAFE_MODE_CONFIG_VALUE = "General Configs.Vanilla Safe Mode";
     private static final String BETTER_DESCRIPTIONS_CONFIG_VALUE = "Client-Only Extensions.Better Descriptions";
     private static final String VAULT_MODIFIER_OVERLAYS_CONFIG_VALUE = "Client-Only Extensions.Vault Modifier Text Overlays";
+    private static final String VAULT_INTERFACE_KEYBINDS_CONFIG_VALUE = "Client-Only Extensions.Vault Interface Keybinds";
     private static final String VAULT_ENCHANTER_EMERALD_SLOT_CONFIG_VALUE = "Client-Server Extensions.Vault Enchanter Emeralds Slot";
-
 
 
     private static void loadConfig(){
@@ -73,11 +81,13 @@ public final class QOLHuntersMixinPlugin implements IMixinConfigPlugin {
                 vanillaSafeMode = config.getOrElse(VANILLA_SAFE_MODE_CONFIG_VALUE, false);
                 betterDescriptions = config.getOrElse(BETTER_DESCRIPTIONS_CONFIG_VALUE, true);
                 vaultModifierOverlays = config.getOrElse(VAULT_MODIFIER_OVERLAYS_CONFIG_VALUE, true);
+                vaultInterfaceKeybinds = config.getOrElse(VAULT_INTERFACE_KEYBINDS_CONFIG_VALUE, true);
                 vaultEnchanterEmeraldSlot = config.getOrElse(VAULT_ENCHANTER_EMERALD_SLOT_CONFIG_VALUE, true);
 
                 QOLHunters.LOGGER.info("QOLHunters: Vanilla Safe Mode: " + vanillaSafeMode);
                 QOLHunters.LOGGER.info("QOLHunters: Better Descriptions: " + betterDescriptions);
-                QOLHunters.LOGGER.info("QOLHunters: Vault Modifier Text Overlays: " + vaultModifierOverlays);
+                QOLHunters.LOGGER.info("QOLHunters: Vault Modifier Overlays: " + vaultModifierOverlays);
+                QOLHunters.LOGGER.info("QOLHunters: Vault Interface Keybinds: " + vaultInterfaceKeybinds);
                 QOLHunters.LOGGER.info("QOLHunters: Vault Enchanter Emeralds Slot: " + vaultEnchanterEmeraldSlot);
 
                 config.close();
@@ -102,6 +112,8 @@ public final class QOLHuntersMixinPlugin implements IMixinConfigPlugin {
             shouldApply = BETTER_DESCRIPTIONS_CONDITIONS.getOrDefault(mixinClassName, TRUE).get();
         } else if(VAULT_MODIFIER_OVERLAYS_CONDITIONS.containsKey(mixinClassName)){
             shouldApply = VAULT_MODIFIER_OVERLAYS_CONDITIONS.getOrDefault(mixinClassName, TRUE).get();
+        } else if(VAULT_KEYBINDS_CONDITIONS.containsKey(mixinClassName)){
+            shouldApply = VAULT_KEYBINDS_CONDITIONS.getOrDefault(mixinClassName, TRUE).get();
         } else {
             shouldApply = TRUE.get();
         }

--- a/src/main/java/io/iridium/qolhunters/config/QOLHuntersClientConfigs.java
+++ b/src/main/java/io/iridium/qolhunters/config/QOLHuntersClientConfigs.java
@@ -8,10 +8,10 @@ public class QOLHuntersClientConfigs {
     public static final ForgeConfigSpec CLIENT_SPEC;
 
     public static final ForgeConfigSpec.ConfigValue<Boolean> VANILLA_SAFE_MODE;
-
     public static final ForgeConfigSpec.ConfigValue<Boolean> BETTER_DESCRIPTIONS;
     public static final ForgeConfigSpec.ConfigValue<Boolean> VAULT_MODIFIER_TEXT_OVERLAYS;
     public static final ForgeConfigSpec.ConfigValue<Boolean> VAULT_ENCHANTER_EMERALDS_SLOT;
+    public static final ForgeConfigSpec.ConfigValue<Boolean> VAULT_INTERFACE_KEYBINDS;
 
     static {
 
@@ -29,8 +29,8 @@ public class QOLHuntersClientConfigs {
         CLIENT_BUILDER.push("Client-Only Extensions");
 
         BETTER_DESCRIPTIONS = CLIENT_BUILDER.comment("Improves the descriptions of abilities, talents, expertises and researches").define("Better Descriptions", true);
-        CLIENT_BUILDER.comment("");
         VAULT_MODIFIER_TEXT_OVERLAYS = CLIENT_BUILDER.comment("Adds text overlays to the Vault modifiers, e.g. '+10% Damage' or 'Speed +1'").define("Vault Modifier Text Overlays", true);
+        VAULT_INTERFACE_KEYBINDS = CLIENT_BUILDER.comment("Adds keybinds to craft/forge/reroll in the Bounty Table, Enchanter, Vault Forge, etc").define("Vault Interface Keybinds", true);
 
         CLIENT_BUILDER.pop();
 

--- a/src/main/java/io/iridium/qolhunters/mixin/keybinds/MixinBountyScreen.java
+++ b/src/main/java/io/iridium/qolhunters/mixin/keybinds/MixinBountyScreen.java
@@ -1,15 +1,9 @@
-package io.iridium.qolhunters.mixin.keybinds.bountytable;
+package io.iridium.qolhunters.mixin.keybinds;
 
 import com.mojang.blaze3d.platform.InputConstants;
 import io.iridium.qolhunters.util.KeyBindings;
-import iskallia.vault.client.gui.framework.render.spi.IElementRenderer;
-import iskallia.vault.client.gui.framework.render.spi.ITooltipRendererFactory;
-import iskallia.vault.client.gui.framework.screen.AbstractElementContainerScreen;
 import iskallia.vault.client.gui.screen.bounty.BountyScreen;
 import iskallia.vault.client.gui.screen.bounty.element.BountyTableContainerElement;
-import iskallia.vault.container.BountyContainer;
-import net.minecraft.network.chat.Component;
-import net.minecraft.world.entity.player.Inventory;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -21,11 +15,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 @Mixin(BountyScreen.class)
-public abstract class MixinBountyScreen extends AbstractElementContainerScreen<BountyContainer> {
-
-    protected MixinBountyScreen(BountyContainer container, Inventory inventory, Component title, IElementRenderer elementRenderer, ITooltipRendererFactory<AbstractElementContainerScreen<BountyContainer>> tooltipRendererFactory) {
-        super(container, inventory, title, elementRenderer, tooltipRendererFactory);
-    }
+public abstract class MixinBountyScreen {
 
     @Shadow(remap = false) @Final
     private BountyTableContainerElement bountyTableContainerElement;

--- a/src/main/java/io/iridium/qolhunters/mixin/keybinds/MixinForgeRecipeContainerScreen.java
+++ b/src/main/java/io/iridium/qolhunters/mixin/keybinds/MixinForgeRecipeContainerScreen.java
@@ -1,0 +1,61 @@
+package io.iridium.qolhunters.mixin.keybinds;
+
+import io.iridium.qolhunters.util.KeyBindings;
+import iskallia.vault.block.entity.base.ForgeRecipeTileEntity;
+import iskallia.vault.client.gui.screen.CatalystInfusionTableScreen;
+import iskallia.vault.client.gui.screen.block.InscriptionTableScreen;
+import iskallia.vault.client.gui.screen.block.ToolStationScreen;
+import iskallia.vault.client.gui.screen.block.VaultForgeScreen;
+import iskallia.vault.client.gui.screen.block.base.ForgeRecipeContainerScreen;
+import iskallia.vault.container.spi.ForgeRecipeContainer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+
+@Mixin(ForgeRecipeContainerScreen.class)
+public abstract class MixinForgeRecipeContainerScreen<V extends ForgeRecipeTileEntity, T extends ForgeRecipeContainer<V>>  {
+
+
+    //Store a list of all screens that are instances of the VaultForgeScreen class
+    private static final List<Class> ForgeRecipeContainerScreens = Arrays.asList(
+            VaultForgeScreen.class,
+            ToolStationScreen.class,
+            CatalystInfusionTableScreen.class,
+            InscriptionTableScreen.class
+    );
+
+    private static boolean isInstanceOfForgeRecipeContainerScreen(Object screen) {
+        for (Class<?> clazz : ForgeRecipeContainerScreens) {
+            if (clazz.isInstance(screen)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+    @Inject(method="keyPressed", at=@At(value="HEAD"), cancellable=true)
+    public void keyPressed(int pKeyCode, int pScanCode, int pModifiers, CallbackInfoReturnable<Boolean> cir) throws InvocationTargetException, IllegalAccessException, NoSuchMethodException {
+
+        if((isInstanceOfForgeRecipeContainerScreen((ForgeRecipeContainerScreen<V,T>)(Object)this))) {
+
+            if(pKeyCode == KeyBindings.FORGE_ITEM.getKey().getValue()) {
+
+                Method onCraftClickMethod = ForgeRecipeContainerScreen.class.getDeclaredMethod("onCraftClick");
+                onCraftClickMethod.setAccessible(true);
+                onCraftClickMethod.invoke((ForgeRecipeContainerScreen<V,T>)(Object)this);
+
+
+                cir.setReturnValue(true);
+            }
+        }
+
+    }
+
+}

--- a/src/main/java/io/iridium/qolhunters/mixin/keybinds/MixinModifierWorkbenchScreen.java
+++ b/src/main/java/io/iridium/qolhunters/mixin/keybinds/MixinModifierWorkbenchScreen.java
@@ -1,0 +1,42 @@
+package io.iridium.qolhunters.mixin.keybinds;
+
+import com.mojang.blaze3d.platform.InputConstants;
+import io.iridium.qolhunters.util.KeyBindings;
+import iskallia.vault.client.gui.framework.render.spi.IElementRenderer;
+import iskallia.vault.client.gui.framework.render.spi.ITooltipRendererFactory;
+import iskallia.vault.client.gui.framework.screen.AbstractElementContainerScreen;
+import iskallia.vault.client.gui.screen.block.ModifierWorkbenchScreen;
+import iskallia.vault.container.ModifierWorkbenchContainer;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Inventory;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ModifierWorkbenchScreen.class)
+public abstract class MixinModifierWorkbenchScreen extends AbstractElementContainerScreen<ModifierWorkbenchContainer> {
+
+
+    protected MixinModifierWorkbenchScreen(ModifierWorkbenchContainer container, Inventory inventory, Component title, IElementRenderer elementRenderer, ITooltipRendererFactory<AbstractElementContainerScreen<ModifierWorkbenchContainer>> tooltipRendererFactory) {
+        super(container, inventory, title, elementRenderer, tooltipRendererFactory);
+    }
+
+    @Inject(method="keyPressed", at=@At("HEAD"), cancellable=true)
+    public void keyPressed(int pKeyCode, int pScanCode, int pModifiers, CallbackInfoReturnable<Boolean> cir)  {
+        InputConstants.Key key = InputConstants.getKey(pKeyCode, pScanCode);
+
+        if (key.equals(KeyBindings.FORGE_ITEM.getKey())) {
+
+            this.tryCraft();
+
+            cir.setReturnValue(true);
+        }
+
+    }
+
+
+    @Shadow(remap = false)
+    private void tryCraft(){}
+}

--- a/src/main/java/io/iridium/qolhunters/mixin/keybinds/MixinVaultEnchanterScreen.java
+++ b/src/main/java/io/iridium/qolhunters/mixin/keybinds/MixinVaultEnchanterScreen.java
@@ -1,0 +1,42 @@
+package io.iridium.qolhunters.mixin.keybinds;
+
+import com.mojang.blaze3d.platform.InputConstants;
+import io.iridium.qolhunters.util.KeyBindings;
+import iskallia.vault.client.gui.framework.render.spi.IElementRenderer;
+import iskallia.vault.client.gui.framework.render.spi.ITooltipRendererFactory;
+import iskallia.vault.client.gui.framework.screen.AbstractElementContainerScreen;
+import iskallia.vault.client.gui.screen.block.VaultEnchanterScreen;
+import iskallia.vault.container.VaultEnchanterContainer;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Inventory;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(VaultEnchanterScreen.class)
+public abstract class MixinVaultEnchanterScreen extends AbstractElementContainerScreen<VaultEnchanterContainer> {
+
+
+    protected MixinVaultEnchanterScreen(VaultEnchanterContainer container, Inventory inventory, Component title, IElementRenderer elementRenderer, ITooltipRendererFactory<AbstractElementContainerScreen<VaultEnchanterContainer>> tooltipRendererFactory) {
+        super(container, inventory, title, elementRenderer, tooltipRendererFactory);
+    }
+
+    @Inject(method="keyPressed", at=@At("HEAD"), cancellable=true)
+    public void keyPressed(int pKeyCode, int pScanCode, int pModifiers, CallbackInfoReturnable<Boolean> cir) {
+        InputConstants.Key key = InputConstants.getKey(pKeyCode, pScanCode);
+
+        if (key.equals(KeyBindings.FORGE_ITEM.getKey())) {
+
+            this.tryCraft();
+
+            cir.setReturnValue(true);
+        }
+
+    }
+
+
+    @Shadow(remap = false)
+    private void tryCraft(){}
+}

--- a/src/main/java/io/iridium/qolhunters/mixin/keybinds/bountytable/MixinBountyScreen.java
+++ b/src/main/java/io/iridium/qolhunters/mixin/keybinds/bountytable/MixinBountyScreen.java
@@ -1,0 +1,49 @@
+package io.iridium.qolhunters.mixin.keybinds.bountytable;
+
+import com.mojang.blaze3d.platform.InputConstants;
+import io.iridium.qolhunters.util.KeyBindings;
+import iskallia.vault.client.gui.framework.render.spi.IElementRenderer;
+import iskallia.vault.client.gui.framework.render.spi.ITooltipRendererFactory;
+import iskallia.vault.client.gui.framework.screen.AbstractElementContainerScreen;
+import iskallia.vault.client.gui.screen.bounty.BountyScreen;
+import iskallia.vault.client.gui.screen.bounty.element.BountyTableContainerElement;
+import iskallia.vault.container.BountyContainer;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Inventory;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+@Mixin(BountyScreen.class)
+public abstract class MixinBountyScreen extends AbstractElementContainerScreen<BountyContainer> {
+
+    protected MixinBountyScreen(BountyContainer container, Inventory inventory, Component title, IElementRenderer elementRenderer, ITooltipRendererFactory<AbstractElementContainerScreen<BountyContainer>> tooltipRendererFactory) {
+        super(container, inventory, title, elementRenderer, tooltipRendererFactory);
+    }
+
+    @Shadow(remap = false) @Final
+    private BountyTableContainerElement bountyTableContainerElement;
+
+    @Inject(method="keyPressed", at=@At("HEAD"), cancellable=true)
+    public void keyPressed(int pKeyCode, int pScanCode, int pModifiers, CallbackInfoReturnable<Boolean> cir) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        InputConstants.Key key = InputConstants.getKey(pKeyCode, pScanCode);
+
+        if (key.equals(KeyBindings.FORGE_ITEM.getKey())) {
+
+            //I used reflection. Sue me.
+            Method handleRerollMethod = bountyTableContainerElement.getClass().getDeclaredMethod("handleReroll");
+            handleRerollMethod.setAccessible(true);
+            handleRerollMethod.invoke(bountyTableContainerElement);
+
+            cir.setReturnValue(true);
+        }
+
+    }
+
+}

--- a/src/main/java/io/iridium/qolhunters/util/KeyBindings.java
+++ b/src/main/java/io/iridium/qolhunters/util/KeyBindings.java
@@ -1,0 +1,19 @@
+package io.iridium.qolhunters.util;
+
+import com.mojang.blaze3d.platform.InputConstants;
+import net.minecraft.client.KeyMapping;
+import net.minecraftforge.client.ClientRegistry;
+import net.minecraftforge.client.settings.KeyConflictContext;
+import org.lwjgl.glfw.GLFW;
+
+public class KeyBindings {
+    public static final String KEY_CATEGORY = "key.categories.qolhunters";
+    public static final String KEY_FORGE = "key.qolhunters.forge";
+
+    public static final KeyMapping FORGE_ITEM = new KeyMapping(KEY_FORGE, KeyConflictContext.GUI, InputConstants.Type.KEYSYM, GLFW.GLFW_KEY_SPACE, KEY_CATEGORY);
+
+    public static void init() {
+        ClientRegistry.registerKeyBinding(FORGE_ITEM);
+    }
+
+}

--- a/src/main/resources/assets/qolhunters/lang/en_us.json
+++ b/src/main/resources/assets/qolhunters/lang/en_us.json
@@ -1,0 +1,4 @@
+{
+  "key.categories.qolhunters": "QOL Hunters",
+  "key.qolhunters.forge": "Press to craft/forge/reroll item depending on the interface."
+}

--- a/src/main/resources/qolhunters.mixins.json
+++ b/src/main/resources/qolhunters.mixins.json
@@ -17,7 +17,10 @@
     "configs.MixinSkillDescriptionsConfig",
     "configs.MixinModConfigs",
     "vaultenchanter.MixinVaultEnchanterScreen",
-    "keybinds.bountytable.MixinBountyScreen"
+    "keybinds.MixinBountyScreen",
+    "keybinds.MixinForgeRecipeContainerScreen",
+    "keybinds.MixinVaultEnchanterScreen",
+    "keybinds.MixinModifierWorkbenchScreen"
   ],
   "minVersion": "0.8"
 }

--- a/src/main/resources/qolhunters.mixins.json
+++ b/src/main/resources/qolhunters.mixins.json
@@ -16,7 +16,8 @@
     "configs.MixinMenuPlayerStatDescriptionConfig",
     "configs.MixinSkillDescriptionsConfig",
     "configs.MixinModConfigs",
-    "vaultenchanter.MixinVaultEnchanterScreen"
+    "vaultenchanter.MixinVaultEnchanterScreen",
+    "keybinds.bountytable.MixinBountyScreen"
   ],
   "minVersion": "0.8"
 }


### PR DESCRIPTION
By default uses spacebar, and works in:
 - Bounty Table 
 - Vault Forge
 - Tool Station
 - Catalyst Infusion Table
 - Inscription Table
 - Modifier Workbench
 - Vault Enchanter

